### PR TITLE
Fix for Spidertron Weapon Switcher link

### DIFF
--- a/_posts/2020-08-28-ALTF4-2.md
+++ b/_posts/2020-08-28-ALTF4-2.md
@@ -41,7 +41,7 @@ The storyline of Factorio as we know it is similar to many familiar base-buildin
 Spidertron Engineer simply replaces The Engineer we all know and love with a cold spidertron robot from the very start of the game. There are technologies along the way that upgrade your character (i.e. spider) and replace the armour upgrades from vanilla. Even this relatively small change really gives the game a different feel. With this mod, I find I am able to engage in the greater universe of the game way more readily. I know it won’t be for everyone (especially arachnophobes) but for me, it takes a minimal part of the game and gives it a twist that ultimately makes the premise and endgame very engaging.
 
 
-### Under the hood: [Spidertron Weapon Switcher](https://mods.factorio.com/SpidertronWeaponSwitcher) <author>Xorimuth</author>
+### Under the hood: [Spidertron Weapon Switcher](https://mods.factorio.com/mod/SpidertronWeaponSwitcher) <author>Xorimuth</author>
 
 Spidertron Weapon Switcher is a mod that allows spidertron to fire any kind of weapon. In this post, I will be talking about how it works behind the scenes. But first, a peek at how awesome this looks in action:
 


### PR DESCRIPTION
Currently leads to https://mods.factorio.com/SpidertronWeaponSwitcher which is a 404