### PR TITLE
#66: Change text color to light gray for links in navbar

### DIFF
--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -41,7 +41,7 @@
 
 .links a {
   white-space: nowrap;
-  color: white;
+  color: #aaa;
 }
 
 .links a:hover {


### PR DESCRIPTION
Fixes #66.