### PR TITLE
Add 'lang' attribute to HTML tag featuring the language code for the current page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.active_lang }}">
   {% include head.html %}
 
   <body>


### PR DESCRIPTION
Fixes #84 (also as #83.2).