### PR TITLE
Update to strikethrough style

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -146,3 +146,7 @@ sub {
   vertical-align: sub;
   font-size: 0.7rem;
 }
+
+s {
+  text-decoration-color: red;
+}


### PR DESCRIPTION
<!--
Thank you for your submission!
-->

### Author info
Name: Jordan Mannfeld
Details: Hi! I was looking into the options for editing the default styles of strikethroughs in Markdown - #259 . Unfortunately there is not much out there in the css spec for stying the strikethroughs using the `~~` syntax. Instead it is recommended to use the `<s>` html element to strikethrough text. This also allows for easier styling. I didn't change a whole lot, but showed how you are able to tweak the styles a bit. I added a `text-decoration-color: red` for the strikethrough color because it's probably the most applicable option. Other possible styles include:

- text-decoration-style (solid, wavy, or dash)
- text-decoration-thickness (I would have used this property, but it is hardly supported in any browsers right now)

<img width="203" alt="Screen Shot 2020-10-30 at 10 42 51 AM" src="https://user-images.githubusercontent.com/16351524/97720099-3d44b500-1a9e-11eb-81d9-3dd0cc1c5282.png">
