### PR TITLE
Native quote transltalion supprt

### DIFF
--- a/_includes/quote.html
+++ b/_includes/quote.html
@@ -1,6 +1,12 @@
 <div class="m0 h100 flex flex-column flex-center quote">
   <blockquote cite="{{ include.cite }}">
     <div class="panel-inset-lighter">
+      {% if include.translation %}
+        <div class="translation">
+          {{ include.translation | default: 'Place Holder' | markdownify }}
+        </div>
+        <hr />
+      {% endif %}
       {{ include.text | default: 'Place Holder' | markdownify }}
       <author>
       — {{ include.author | default: 'Place Holder'}}

--- a/_posts/de/2020-10-23-ALTF4-10.md
+++ b/_posts/de/2020-10-23-ALTF4-10.md
@@ -95,7 +95,17 @@ Und vielleicht das... <br/>
 ```Der Spieler, genannt Alden Winters ...```
 {% endcapture %}
 
-{% include quote.html text=quote_text author='Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 Es scheint, als wären bereits vor langer Zeit Pläne für eine offizielle Factorio-Geschichte vorhanden gewesen, und sie scheinen sehr detailliert zu sein. Aber diese Idee wurde verworfen und nie implementiert, worüber Klonan rückblickend [froh ist](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565).
 

--- a/_posts/de/2020-11-06-ALTF4-12.md
+++ b/_posts/de/2020-11-06-ALTF4-12.md
@@ -24,9 +24,7 @@ Als wir diese Seite eingerichtet haben, war klar, dass der Spidertron etwas tun 
 
 Der ursprüngliche Plan war, dass der Spidertron die Seite hochkrabbelt und so wie der zurück-nach-oben-Knopf auf der Factorioseite funktioniert. Das benötigt eine Aufnahme des Spidertrons, wie er nach oben läuft und dann eine Wiederholung der Aufnahme, während er nach oben läuft. Dann hatte Dr.MagPie die Idee, dass der Spidertron auf der Seite der Fernbedienung folgt, so wie im Spiel. Das ist etwas, das mit Aufnahmen nicht mehr zu realisieren ist, da viel zu viele Aufnahmen von möglichen Bewegungen notwendig wären.
 
-{% include quote.html text='Doch so, wie ich die Community kenne, wird es einige Verrückte geben, die dabei helfen würden, einfach nur, weil es eine Herausforderung ist ...
-<hr />
-Though knowing our community, there are probably some mad lads that would help with this just for the sake of it being a challenge....' author='psihius (3. Oktober 2020)'%}
+{% include quote.html text='Though knowing our community, there are probably some mad lads that would help with this just for the sake of it being a challenge....' translation='Doch so, wie ich die Community kenne, wird es einige Verrückte geben, die dabei helfen würden, einfach nur, weil es eine Herausforderung ist ...' author='psihius (October 3, 2020)'%}
 
 *Herausforderung angenommen*
 

--- a/_posts/es/2020-10-23-ALTF4-10.md
+++ b/_posts/es/2020-10-23-ALTF4-10.md
@@ -95,7 +95,17 @@ Y tal vez esto... <br/>
 ```El jugador, llamado Alden Winters...```
 {% endcapture %}
 
-{% include quote.html text=quote_text author='Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 Parece que había planes para una historia oficial de Factorio hace mucho tiempo, y siguiendo el estilo típico de Wube, parecía muy detallada. Sin embargo, esta idea se descartó y nunca se implementó, por lo que Klonan estaba [contento](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565) de recordarlo.
 

--- a/_posts/fr/2020-10-23-ALTF4-10.md
+++ b/_posts/fr/2020-10-23-ALTF4-10.md
@@ -96,7 +96,17 @@ Et peut-être ceci...<br/>
 ```Le joueur, nommé Alden Winters...```
 {% endcapture %}
 
-{% include quote.html text=quote_text author='Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 Il semble qu'il y ait eu des plans pour une longue histoire officielle pour Factorio il y a longtemps, et qu'elle était très détaillée, à la façon de Wube. Cependant, cette idée a été rejetée et jamais implémentée, ce que Klonan considère, avec du recul, comme [très bien](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565).
 

--- a/_posts/fr/2020-11-06-ALTF4-12.md
+++ b/_posts/fr/2020-11-06-ALTF4-12.md
@@ -23,9 +23,7 @@ Quand nous avons créé ce site, il était clair que nous devions faire faire qu
 
 L'idée de base était de faire ramper le spidertron jusqu'en haut de la page et pouvoir l'utiliser comme bouton pour remonter au sommet de la page, comme la fusée sur le site Internet officiel de Factorio. Cela nécessitait d'enregistrer une boucle d'un spidertron marchant vers le haut et de la mettre en boucle en le faisant remonter vers le sommet de la page. Puis Dr.MagPie eut l'idée de le faire suivre une télécommande, comme dans le jeu. Cela allait beaucoup plus loin que ce qu'il était possible de faire avec des enregistrements, puisqu'il faudrait beaucoup trop de combinaisons différentes.
 
-{% include quote.html text='Mais connaissant notre communauté, il y a probablement des fous prêts à nous aider juste pour relever le défi...
-<hr />
-Though knowing our community, there are probably some mad lads that would help with this just for the sake of it being a challenge....' author='psihius (3 octobre 2020)'%}
+{% include quote.html text='Though knowing our community, there are probably some mad lads that would help with this just for the sake of it being a challenge....' translation='Mais connaissant notre communauté, il y a probablement des fous prêts à nous aider juste pour relever le défi...' author='psihius (October 3, 2020)'%}
 
 *Défi accepté*
 

--- a/_posts/it/2020-10-23-ALTF4-10.md
+++ b/_posts/it/2020-10-23-ALTF4-10.md
@@ -95,7 +95,17 @@ E forse anche questo...<br/>
 ```Il player, chiamato Alden Winters...```
 {% endcapture %}
 
-{% include quote.html text=quote_text author='Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 Sembra ci fossero piani per una storia ufficiale di Factorio tempo fa, e in tipico stile Wube, è molto dettagliata. L'idea venne però scartata e non fu mai implementata, cosa per la quale Klonan fu [felicissimo](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565) con senno di poi.
 

--- a/_posts/nl/2020-10-23-ALTF4-10.md
+++ b/_posts/nl/2020-10-23-ALTF4-10.md
@@ -95,7 +95,17 @@ En misschien dit...<br/>
 ```De speler, genaamd Alden Winters...```
 {% endcapture %}
 
-{% include quote.html text=quote_text author='Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 Het lijkt erop dat er lang gelden plannen waren voor een officieel Factorio-verhaald, en dat deze op typische Wube-manier heel erg gedetailleerd lijkt te zijn. Dit idee werd echter geschrapt en is nooit in het spel ge�mplementeerd, waar Klonan achteraf gezien [blij](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565) mee was.
 

--- a/_posts/ru/2020-10-23-ALTF4-10.md
+++ b/_posts/ru/2020-10-23-ALTF4-10.md
@@ -96,7 +96,17 @@ discuss:
 ```Игрок по имени Олден Винтерс ...```
 {% endcapture%}
 
-{% include quote.html text = quote_text author = 'Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 Похоже, что давно были планы на официальную историю Factorio, и в типичной манере Wube она кажется очень подробной. Однако эта идея была отброшена и так и не реализована, чему Клонан был [рад](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565) в ретроспективе.
 

--- a/_posts/zh/2020-10-23-ALTF4-10.md
+++ b/_posts/zh/2020-10-23-ALTF4-10.md
@@ -95,7 +95,17 @@ discuss:
 ```玩家，名为奥尔登·温特斯（Alden Winters）…```
 {% endcapture %}
 
-{% include quote.html text=quote_text author='Klonan'%}
+{% capture quote_text_english %}
+this is all you get:
+```
+The Cova System is named for the orange dwarf star at its centre. Four known planets orbit the star, as well as numerous moons, unlisted dwarf planets and asteroids.
+Closest to the star is Nauvis - this is the planet upon which the game takes place. A temperate world capable of sustaining life.
+```
+And maybe this...<br/>
+```The player, named Alden Winters...```
+{% endcapture %}
+
+{% include quote.html text=quote_text_english translation=quote_text author='Klonan'%}
 
 看起来很久之前有过编写官方异星工厂故事的计划，而且按照 Wube 的风格会是一个非常详细的故事。不过这个想法最终取消没有进入游戏中，事后看来 Klonan 对此[很开心](https://discordapp.com/channels/139677590393716737/603392474458882065/766688031687573565)。
 

--- a/_posts/zh/2020-11-06-ALTF4-12.md
+++ b/_posts/zh/2020-11-06-ALTF4-12.md
@@ -23,7 +23,7 @@ discuss:
 
 最初的计划是让蜘蛛机甲爬上页面，和异星工厂官方网站上的火箭一样，成为回到顶部的按钮。这需要录制一个向上行走的动画，然后在我们将其向上移动时循环播放。然后，Dr.MagPie 想到了让蜘蛛机甲跟着遥控器在页面上走，就像游戏中一样。这远远超出了使用录像能够做到的范围，因为这需要太多的组合。
 
-{% include quote.html text='考虑到这是我们所知的社区，可能真会有一些疯狂的伙计会来挑战不可能…' author='psihius（10月3日，2020）'%}
+{% include quote.html text='Though knowing our community, there are probably some mad lads that would help with this just for the sake of it being a challenge....' translation='考虑到这是我们所知的社区，可能真会有一些疯狂的伙计会来挑战不可能…' author='psihius (October 3, 2020)'%}
 
 *接受挑战*
 


### PR DESCRIPTION
As discussed in DS native translation support for quote embed.

translation `div` has `translation` `class` so it can have additional styling. I don't really know how to style it. I guess we can add it later based on feedback. Or some one else can tackle it. 

`{% include quote.html text='test' author='DrMagPie' translation='tset'%}`
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/23652900/98440560-26d3d480-2102-11eb-86f3-094809ad62ad.png">
