### PR TITLE
Update spidertron (performance fixes)

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -14,7 +14,6 @@ body {
   font-size: 100%;
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 body {

--- a/assets/GLOBAL/css/spidertron.css
+++ b/assets/GLOBAL/css/spidertron.css
@@ -39,21 +39,21 @@ SOFTWARE.
 }
 
 .spidertron-home {
-    width: 1px;
-    height: 1px;
+    width: 0px;
+    height: 0px;
 }
 
 .spidertron {
     position: absolute;
-    top: var(--spidertron-location-y);
-    left: var(--spidertron-location-x);
+    top: 0px;
+    left: 0px;
     contain: strict;
 
     width: var(--spidertron-width);
     height: var(--spidertron-height);
     /* border: 2px solid red; */
 
-    transform: scale(var(--spidertron-scale));
+    transform: translate(var(--spidertron-location-x), var(--spidertron-location-y)) scale(var(--spidertron-scale));
     transform-origin: top left;
     z-index: 200;
 
@@ -62,29 +62,41 @@ SOFTWARE.
 
 .spidertron-body {
     position: absolute;
-    left: var(--spidertron-body-x);
-    top: var(--spidertron-body-y);
+    left: 0px;
+    top: 0px;
 
     width: 66px;
     height: 80px;
     margin-left: -33px;
     margin-top: -80px;
 
+    transform: translate(var(--spidertron-body-x), var(--spidertron-body-y));
+
     background-image: url(https://media.alt-f4.blog/spidertron/spidertron-body.png);
     background-size: 100% 100%;
 }
 
-.spidertron-leg-upper {
+.spidertron-leg-wrapper {
     position: absolute;
-
-    width: 22px;
     transform-origin: top left;
 }
 
+.spidertron-leg-upper {
+    position: absolute;
+    width: 22px;
+
+    margin-left: -11px;
+    margin-top: -4px;
+    padding-top: 4px;
+    padding-bottom: 8px;
+
+    contain: strict;
+}
+
 .spidertron-leg-upper-end-a {
-    position: relative;
-    top: -4px;
-    left: -11px;
+    position: absolute;
+    top: 0px;
+    left: 0px;
 
     width: 22px;
     height: 44px;
@@ -94,42 +106,11 @@ SOFTWARE.
     background-size: 800% 100%;
 }
 
-.spidertron-leg1-upper .spidertron-leg-upper-end-a {
-    background-position: 0px 0px;
-}
-.spidertron-leg2-upper .spidertron-leg-upper-end-a {
-    background-position: -22px 0px;
-    transform: scaleY(0.95);
-}
-.spidertron-leg3-upper .spidertron-leg-upper-end-a {
-    background-position: -44px 0px;
-    transform: scaleY(0.85);
-}
-.spidertron-leg4-upper .spidertron-leg-upper-end-a {
-    background-position: -66px 0px;
-    transform: scaleY(0.65);
-}
-.spidertron-leg5-upper .spidertron-leg-upper-end-a {
-    background-position: -88px 0px;
-}
-.spidertron-leg6-upper .spidertron-leg-upper-end-a {
-    background-position: -110px 0px;
-    transform: scaleY(0.95);
-}
-.spidertron-leg7-upper .spidertron-leg-upper-end-a {
-    background-position: -132px 0px;
-    transform: scaleY(0.85);
-}
-.spidertron-leg8-upper .spidertron-leg-upper-end-a {
-    background-position: -154px 0px;
-    transform: scaleY(0.65);
-}
-
 .spidertron-leg-upper-stretchable {
     position: absolute;
     top: 8px;
-    left: -8px;
-    bottom: 8px;
+    left: 3px;
+    bottom: 16px;
 
     width: 15px;
 
@@ -139,8 +120,8 @@ SOFTWARE.
 
 .spidertron-leg-upper-end-b {
     position: absolute;
-    left: -9px;
-    bottom: -5px;
+    left: 2px;
+    bottom: 3px;
 
     width: 20px;
     height: 30px;
@@ -150,41 +131,10 @@ SOFTWARE.
     background-size: 800% 100%;
 }
 
-.spidertron-leg1-upper .spidertron-leg-upper-end-b {
-    background-position: 0px 0px;
-}
-.spidertron-leg2-upper .spidertron-leg-upper-end-b {
-    background-position: -20px 0px;
-    transform: scaleY(0.95);
-}
-.spidertron-leg3-upper .spidertron-leg-upper-end-b {
-    background-position: -40px 0px;
-    transform: scaleY(0.85);
-}
-.spidertron-leg4-upper .spidertron-leg-upper-end-b {
-    background-position: -60px 0px;
-    transform: scaleY(0.65);
-}
-.spidertron-leg5-upper .spidertron-leg-upper-end-b {
-    background-position: -80px 0px;
-}
-.spidertron-leg6-upper .spidertron-leg-upper-end-b {
-    background-position: -100px 0px;
-    transform: scaleY(0.95);
-}
-.spidertron-leg7-upper .spidertron-leg-upper-end-b {
-    background-position: -120px 0px;
-    transform: scaleY(0.85);
-}
-.spidertron-leg8-upper .spidertron-leg-upper-end-b {
-    background-position: -140px 0px;
-    transform: scaleY(0.65);
-}
-
 .spidertron-leg-knee {
     position: absolute;
-    bottom: -8px;
-    left: -6px;
+    bottom: 0px;
+    left: 5px;
 
     width: 12px;
     height: 14px;
@@ -193,54 +143,38 @@ SOFTWARE.
     background-size: 800% 100%;
 }
 
-.spidertron-leg1-knee { background-position: 0px 0px; }
-.spidertron-leg2-knee { background-position: -12px 0px; }
-.spidertron-leg3-knee { background-position: -24px 0px; }
-.spidertron-leg4-knee { background-position: -36px 0px; }
-.spidertron-leg5-knee { background-position: -48px 0px; }
-.spidertron-leg6-knee { background-position: -60px 0px; }
-.spidertron-leg7-knee { background-position: -72px 0px; }
-.spidertron-leg8-knee { background-position: -84px 0px; }
-
 .spidertron-leg-lower {
     position: absolute;
-
     width: 20px;
-    transform-origin: top left;
+
+    margin-left: -10px;
+    margin-top: -5px;
+    padding-top: 5px;
+    padding-bottom: 1px;
+
+    contain: strict;
+    transform: rotate(180deg);
 }
 
 .spidertron-leg-lower-end-a {
     position: absolute;
-    bottom: -5px;
-    left: -10px;
+    top: 0px;
+    left: 0px;
 
     width: 20px;
     height: 50px;
-
-    transform: rotate(180deg);
 
     background-image: url(https://media.alt-f4.blog/spidertron/spidertron-legs-lower-end-A.png);
     background-size: 800% 100%;
 }
 
-.spidertron-leg1-lower .spidertron-leg-lower-end-a { background-position: 0px 0px; }
-.spidertron-leg2-lower .spidertron-leg-lower-end-a { background-position: -20px 0px; }
-.spidertron-leg3-lower .spidertron-leg-lower-end-a { background-position: -40px 0px; }
-.spidertron-leg4-lower .spidertron-leg-lower-end-a { background-position: -60px 0px; }
-.spidertron-leg5-lower .spidertron-leg-lower-end-a { background-position: -80px 0px; }
-.spidertron-leg6-lower .spidertron-leg-lower-end-a { background-position: -100px 0px; }
-.spidertron-leg7-lower .spidertron-leg-lower-end-a { background-position: -120px 0px; }
-.spidertron-leg8-lower .spidertron-leg-lower-end-a { background-position: -140px 0px; }
-
 .spidertron-leg-lower-stretchable {
     position: absolute;
-    top: 25px;
-    bottom: 12px;
-    left: -6px;
+    top: 12px;
+    bottom: 25px;
+    left: 4px;
 
     width: 12px;
-
-    transform: rotate(180deg);
 
     background-image: url(https://media.alt-f4.blog/spidertron/spidertron-legs-lower-stretchable.png);
     background-size: 800% 100%;
@@ -248,75 +182,50 @@ SOFTWARE.
 
 .spidertron-leg-lower-end-b {
     position: absolute;
-    top: -1px;
-    left: -9px;
+    bottom: 0px;
+    left: 1px;
 
     width: 18px;
     height: 46px;
-
-    transform: rotate(180deg);
 
     background-image: url(https://media.alt-f4.blog/spidertron/spidertron-legs-lower-end-B.png);
     background-size: 800% 100%;
 }
 
-.spidertron-leg1-lower .spidertron-leg-lower-end-b { background-position: 0px 0px; }
-.spidertron-leg2-lower .spidertron-leg-lower-end-b { background-position: -18px 0px; }
-.spidertron-leg3-lower .spidertron-leg-lower-end-b { background-position: -36px 0px; }
-.spidertron-leg4-lower .spidertron-leg-lower-end-b { background-position: -54px 0px; }
-.spidertron-leg5-lower .spidertron-leg-lower-end-b { background-position: -72px 0px; }
-.spidertron-leg6-lower .spidertron-leg-lower-end-b { background-position: -90px 0px; }
-.spidertron-leg7-lower .spidertron-leg-lower-end-b { background-position: -108px 0px; }
-.spidertron-leg8-lower .spidertron-leg-lower-end-b { background-position: -126px 0px; }
+/* Leg CSS Variables */
+.spidertron-leg1-upper-wrapper {
+    transform: translate(var(--leg1-upper-location-x), var(--leg1-upper-location-y)) rotate(var(--leg1-upper-angle));
+}
+.spidertron-leg2-upper-wrapper {
+    transform: translate(var(--leg2-upper-location-x), var(--leg2-upper-location-y)) rotate(var(--leg2-upper-angle));
+}
+.spidertron-leg3-upper-wrapper {
+    transform: translate(var(--leg3-upper-location-x), var(--leg3-upper-location-y)) rotate(var(--leg3-upper-angle));
+}
+.spidertron-leg4-upper-wrapper {
+    transform: translate(var(--leg4-upper-location-x), var(--leg4-upper-location-y)) rotate(var(--leg4-upper-angle));
+}
+.spidertron-leg5-upper-wrapper {
+    transform: translate(var(--leg5-upper-location-x), var(--leg5-upper-location-y)) rotate(var(--leg5-upper-angle));
+}
+.spidertron-leg6-upper-wrapper {
+    transform: translate(var(--leg6-upper-location-x), var(--leg6-upper-location-y)) rotate(var(--leg6-upper-angle));
+}
+.spidertron-leg7-upper-wrapper {
+    transform: translate(var(--leg7-upper-location-x), var(--leg7-upper-location-y)) rotate(var(--leg7-upper-angle));
+}
+.spidertron-leg8-upper-wrapper {
+    transform: translate(var(--leg8-upper-location-x), var(--leg8-upper-location-y)) rotate(var(--leg8-upper-angle));
+}
 
-.spidertron-leg1-upper {
-    left: var(--leg1-upper-location-x);
-    top: var(--leg1-upper-location-y);
-    height: var(--leg1-upper-length);
-    transform: rotate(var(--leg1-upper-angle));
-}
-.spidertron-leg2-upper {
-    left: var(--leg2-upper-location-x);
-    top: var(--leg2-upper-location-y);
-    height: var(--leg2-upper-length);
-    transform: rotate(var(--leg2-upper-angle));
-}
-.spidertron-leg3-upper {
-    left: var(--leg3-upper-location-x);
-    top: var(--leg3-upper-location-y);
-    height: var(--leg3-upper-length);
-    transform: rotate(var(--leg3-upper-angle));
-}
-.spidertron-leg4-upper {
-    left: var(--leg4-upper-location-x);
-    top: var(--leg4-upper-location-y);
-    height: var(--leg4-upper-length);
-    transform: rotate(var(--leg4-upper-angle));
-}
-.spidertron-leg5-upper {
-    left: var(--leg5-upper-location-x);
-    top: var(--leg5-upper-location-y);
-    height: var(--leg5-upper-length);
-    transform: rotate(var(--leg5-upper-angle));
-}
-.spidertron-leg6-upper {
-    left: var(--leg6-upper-location-x);
-    top: var(--leg6-upper-location-y);
-    height: var(--leg6-upper-length);
-    transform: rotate(var(--leg6-upper-angle));
-}
-.spidertron-leg7-upper {
-    left: var(--leg7-upper-location-x);
-    top: var(--leg7-upper-location-y);
-    height: var(--leg7-upper-length);
-    transform: rotate(var(--leg7-upper-angle));
-}
-.spidertron-leg8-upper {
-    left: var(--leg8-upper-location-x);
-    top: var(--leg8-upper-location-y);
-    height: var(--leg8-upper-length);
-    transform: rotate(var(--leg8-upper-angle));
-}
+.spidertron-leg1-upper { height: var(--leg1-upper-length); }
+.spidertron-leg2-upper { height: var(--leg2-upper-length); }
+.spidertron-leg3-upper { height: var(--leg3-upper-length); }
+.spidertron-leg4-upper { height: var(--leg4-upper-length); }
+.spidertron-leg5-upper { height: var(--leg5-upper-length); }
+.spidertron-leg6-upper { height: var(--leg6-upper-length); }
+.spidertron-leg7-upper { height: var(--leg7-upper-length); }
+.spidertron-leg8-upper { height: var(--leg8-upper-length); }
 
 .spidertron-leg1-knee { transform: rotate(var(--leg1-knee-angle)); }
 .spidertron-leg2-knee { transform: rotate(var(--leg2-knee-angle)); }
@@ -327,51 +236,82 @@ SOFTWARE.
 .spidertron-leg7-knee { transform: rotate(var(--leg7-knee-angle)); }
 .spidertron-leg8-knee { transform: rotate(var(--leg8-knee-angle)); }
 
-.spidertron-leg1-lower {
-    left: var(--leg1-lower-location-x);
-    top: var(--leg1-lower-location-y);
-    height: var(--leg1-lower-length);
-    transform: rotate(var(--leg1-lower-angle));
+.spidertron-leg1-lower-wrapper {
+    transform: translate(var(--leg1-lower-location-x), var(--leg1-lower-location-y)) rotate(var(--leg1-lower-angle));
 }
-.spidertron-leg2-lower {
-    left: var(--leg2-lower-location-x);
-    top: var(--leg2-lower-location-y);
-    height: var(--leg2-lower-length);
-    transform: rotate(var(--leg2-lower-angle));
+.spidertron-leg2-lower-wrapper {
+    transform: translate(var(--leg2-lower-location-x), var(--leg2-lower-location-y)) rotate(var(--leg2-lower-angle));
 }
-.spidertron-leg3-lower {
-    left: var(--leg3-lower-location-x);
-    top: var(--leg3-lower-location-y);
-    height: var(--leg3-lower-length);
-    transform: rotate(var(--leg3-lower-angle));
+.spidertron-leg3-lower-wrapper {
+    transform: translate(var(--leg3-lower-location-x), var(--leg3-lower-location-y)) rotate(var(--leg3-lower-angle));
 }
-.spidertron-leg4-lower {
-    left: var(--leg4-lower-location-x);
-    top: var(--leg4-lower-location-y);
-    height: var(--leg4-lower-length);
-    transform: rotate(var(--leg4-lower-angle));
+.spidertron-leg4-lower-wrapper {
+    transform: translate(var(--leg4-lower-location-x), var(--leg4-lower-location-y)) rotate(var(--leg4-lower-angle));
 }
-.spidertron-leg5-lower {
-    left: var(--leg5-lower-location-x);
-    top: var(--leg5-lower-location-y);
-    height: var(--leg5-lower-length);
-    transform: rotate(var(--leg5-lower-angle));
+.spidertron-leg5-lower-wrapper {
+    transform: translate(var(--leg5-lower-location-x), var(--leg5-lower-location-y)) rotate(var(--leg5-lower-angle));
 }
-.spidertron-leg6-lower {
-    left: var(--leg6-lower-location-x);
-    top: var(--leg6-lower-location-y);
-    height: var(--leg6-lower-length);
-    transform: rotate(var(--leg6-lower-angle));
+.spidertron-leg6-lower-wrapper {
+    transform: translate(var(--leg6-lower-location-x), var(--leg6-lower-location-y)) rotate(var(--leg6-lower-angle));
 }
-.spidertron-leg7-lower {
-    left: var(--leg7-lower-location-x);
-    top: var(--leg7-lower-location-y);
-    height: var(--leg7-lower-length);
-    transform: rotate(var(--leg7-lower-angle));
+.spidertron-leg7-lower-wrapper {
+    transform: translate(var(--leg7-lower-location-x), var(--leg7-lower-location-y)) rotate(var(--leg7-lower-angle));
 }
-.spidertron-leg8-lower {
-    left: var(--leg8-lower-location-x);
-    top: var(--leg8-lower-location-y);
-    height: var(--leg8-lower-length);
-    transform: rotate(var(--leg8-lower-angle));
+.spidertron-leg8-lower-wrapper {
+    transform: translate(var(--leg8-lower-location-x), var(--leg8-lower-location-y)) rotate(var(--leg8-lower-angle));
 }
+
+.spidertron-leg1-lower { height: var(--leg1-lower-length); }
+.spidertron-leg2-lower { height: var(--leg2-lower-length); }
+.spidertron-leg3-lower { height: var(--leg3-lower-length); }
+.spidertron-leg4-lower { height: var(--leg4-lower-length); }
+.spidertron-leg5-lower { height: var(--leg5-lower-length); }
+.spidertron-leg6-lower { height: var(--leg6-lower-length); }
+.spidertron-leg7-lower { height: var(--leg7-lower-length); }
+.spidertron-leg8-lower { height: var(--leg8-lower-length); }
+
+/* Sprite Offsets */
+.spidertron-leg1-upper .spidertron-leg-upper-end-a { background-position: 0px 0px; }
+.spidertron-leg2-upper .spidertron-leg-upper-end-a { background-position: -22px 0px; transform: scaleY(0.95); }
+.spidertron-leg3-upper .spidertron-leg-upper-end-a { background-position: -44px 0px; transform: scaleY(0.85); }
+.spidertron-leg4-upper .spidertron-leg-upper-end-a { background-position: -66px 0px; transform: scaleY(0.65); }
+.spidertron-leg5-upper .spidertron-leg-upper-end-a { background-position: -88px 0px; }
+.spidertron-leg6-upper .spidertron-leg-upper-end-a { background-position: -110px 0px; transform: scaleY(0.95); }
+.spidertron-leg7-upper .spidertron-leg-upper-end-a { background-position: -132px 0px; transform: scaleY(0.85); }
+.spidertron-leg8-upper .spidertron-leg-upper-end-a { background-position: -154px 0px; transform: scaleY(0.65); }
+
+.spidertron-leg1-upper .spidertron-leg-upper-end-b { background-position: 0px 0px; }
+.spidertron-leg2-upper .spidertron-leg-upper-end-b { background-position: -20px 0px; transform: scaleY(0.95); }
+.spidertron-leg3-upper .spidertron-leg-upper-end-b { background-position: -40px 0px; transform: scaleY(0.85); }
+.spidertron-leg4-upper .spidertron-leg-upper-end-b { background-position: -60px 0px; transform: scaleY(0.65); }
+.spidertron-leg5-upper .spidertron-leg-upper-end-b { background-position: -80px 0px; }
+.spidertron-leg6-upper .spidertron-leg-upper-end-b { background-position: -100px 0px; transform: scaleY(0.95); }
+.spidertron-leg7-upper .spidertron-leg-upper-end-b { background-position: -120px 0px; transform: scaleY(0.85); }
+.spidertron-leg8-upper .spidertron-leg-upper-end-b { background-position: -140px 0px; transform: scaleY(0.65); }
+
+.spidertron-leg1-knee { background-position: 0px 0px; }
+.spidertron-leg2-knee { background-position: -12px 0px; }
+.spidertron-leg3-knee { background-position: -24px 0px; }
+.spidertron-leg4-knee { background-position: -36px 0px; }
+.spidertron-leg5-knee { background-position: -48px 0px; }
+.spidertron-leg6-knee { background-position: -60px 0px; }
+.spidertron-leg7-knee { background-position: -72px 0px; }
+.spidertron-leg8-knee { background-position: -84px 0px; }
+
+.spidertron-leg1-lower .spidertron-leg-lower-end-a { background-position: 0px 0px; }
+.spidertron-leg2-lower .spidertron-leg-lower-end-a { background-position: -20px 0px; }
+.spidertron-leg3-lower .spidertron-leg-lower-end-a { background-position: -40px 0px; }
+.spidertron-leg4-lower .spidertron-leg-lower-end-a { background-position: -60px 0px; }
+.spidertron-leg5-lower .spidertron-leg-lower-end-a { background-position: -80px 0px; }
+.spidertron-leg6-lower .spidertron-leg-lower-end-a { background-position: -100px 0px; }
+.spidertron-leg7-lower .spidertron-leg-lower-end-a { background-position: -120px 0px; }
+.spidertron-leg8-lower .spidertron-leg-lower-end-a { background-position: -140px 0px; }
+
+.spidertron-leg1-lower .spidertron-leg-lower-end-b { background-position: 0px 0px; }
+.spidertron-leg2-lower .spidertron-leg-lower-end-b { background-position: -18px 0px; }
+.spidertron-leg3-lower .spidertron-leg-lower-end-b { background-position: -36px 0px; }
+.spidertron-leg4-lower .spidertron-leg-lower-end-b { background-position: -54px 0px; }
+.spidertron-leg5-lower .spidertron-leg-lower-end-b { background-position: -72px 0px; }
+.spidertron-leg6-lower .spidertron-leg-lower-end-b { background-position: -90px 0px; }
+.spidertron-leg7-lower .spidertron-leg-lower-end-b { background-position: -108px 0px; }
+.spidertron-leg8-lower .spidertron-leg-lower-end-b { background-position: -126px 0px; }

--- a/assets/GLOBAL/js/spidertron.js
+++ b/assets/GLOBAL/js/spidertron.js
@@ -408,10 +408,16 @@ function updateSpidertron(spidertron, time) {
                    '--leg' + (N + 1) + '-knee-angle:' + -((lowerAngle + upperAngle) / 2) + 'rad;';
     }
 
-    cssText += '--spidertron-location-x:' + (spidertron.currentX + spidertron.boundingBox.x) + 'px;' +
-               '--spidertron-location-y:' + (spidertron.currentY + spidertron.boundingBox.y) + 'px;' +
-               '--spidertron-width:' + (spidertron.boundingBox.width / spidertron.scale) + 'px;' +
-               '--spidertron-height:' + (spidertron.boundingBox.height / spidertron.scale) + 'px;' +
+    // Crop spidertron if it goes outside the document body so that it doesn't cause page resizes.
+    let locationX = Math.min(bodyRect.width, spidertron.currentX + spidertron.boundingBox.x);
+    let locationY = Math.min(bodyRect.height, spidertron.currentY + spidertron.boundingBox.y);
+    let scaledWidth = Math.max(0, Math.min(bodyRect.width - locationX, spidertron.boundingBox.width)) / spidertron.scale;
+    let scaledHeight = Math.max(0, Math.min(bodyRect.height - locationY, spidertron.boundingBox.height)) / spidertron.scale;
+
+    cssText += '--spidertron-location-x:' + locationX + 'px;' +
+               '--spidertron-location-y:' + locationY + 'px;' +
+               '--spidertron-width:' + scaledWidth + 'px;' +
+               '--spidertron-height:' + scaledHeight + 'px;' +
                '--spidertron-body-x:' + (bodyOffsetX - spidertron.boundingBox.x) / spidertron.scale + 'px;' +
                '--spidertron-body-y:' + ((bodyOffsetY - spidertron.boundingBox.y) / spidertron.scale - bodyHeight) + 'px;';
 


### PR DESCRIPTION
In an effort to improve the performance on mobile, I've implemented `u/gtsteel`'s suggestion to use `transform:` instead of `left:`.
Removing `width:` and `height:` changes and using scale transforms instead will also improve performance, but will require a more complicated change, so that's for a later PR.

I've also added some code to the javascript to prevent Spidertron from causing a page resize when walking off the bottom or right of the screen, which causes a ton of lag on mobile.