### PR TITLE
Fix body height on short pages

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -14,6 +14,7 @@ body {
   font-size: 100%;
   display: flex;
   flex-direction: column;
+  min-height: 100%;
 }
 
 body {


### PR DESCRIPTION
This fixes https://github.com/AlternativeFFFF/Alt-F4/issues/307

This also causes the footer to stick to the bottom of the window on short pages like it used to before #290 

![](https://puu.sh/GOGmp/ded2dbf1b4.png)