### PR TITLE
Submissions relabeled discord notifications

### DIFF
--- a/.github/workflows/PR_Labeled_Notify.yml
+++ b/.github/workflows/PR_Labeled_Notify.yml
@@ -30,4 +30,4 @@ jobs:
         DISCORD_AVATAR: 'https://raw.githubusercontent.com/AlternativeFFFF/Alt-F4/master/assets/GLOBAL/img/spider.png'	
       uses: Ilshidur/action-discord@0.2.0	
       with:	
-        args: "{{ EVENT_PAYLOAD.pull_request.title }} has been updated.\nCurrent labels are {{ EVENT_PAYLOAD.pull_request.labels }}\n{{ EVENT_PAYLOAD.pull_request.html_url }}"
+        args: "*{{ EVENT_PAYLOAD.pull_request.title }}* - has been updated.\n{{ EVENT_PAYLOAD.pull_request.html_url }}"

--- a/.github/workflows/PR_Labeled_Notify.yml
+++ b/.github/workflows/PR_Labeled_Notify.yml
@@ -30,4 +30,4 @@ jobs:
         DISCORD_AVATAR: 'https://raw.githubusercontent.com/AlternativeFFFF/Alt-F4/master/assets/GLOBAL/img/spider.png'	
       uses: Ilshidur/action-discord@0.2.0	
       with:	
-        args: "*{{ EVENT_PAYLOAD.pull_request.title }}* - has been updated.\n{{ EVENT_PAYLOAD.pull_request.html_url }}"
+        args: "*{{ EVENT_PAYLOAD.pull_request.title }}* - has been updated.\nCurrent labels are {{ EVENT_PAYLOAD.pull_request.labels }}\n{{ EVENT_PAYLOAD.pull_request.html_url }}"

--- a/.github/workflows/PR_Labeled_Notify.yml
+++ b/.github/workflows/PR_Labeled_Notify.yml
@@ -1,0 +1,33 @@
+name: PR Labeled Notfiy
+
+on:	
+  pull_request_target:	
+    branches:	
+      - master
+    types:	
+      - labeled	
+
+jobs:	
+  notify:	
+    name: Notification	
+    #if: github.repository == 'AlternativeFFFF/Alt-F4'	
+    runs-on: ubuntu-latest	
+    steps:	
+
+    - name: Checkout PR	
+      uses: actions/checkout@master	
+
+    - id: checkLabel	
+      uses: Dreamcodeio/pr-has-label-action@master	
+      with:	
+        label: impact:submission	
+
+    - name: Discord notification	
+      if: steps.checkLabel.outputs.hasLabel	
+      env:	
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_EDITORIAL }}	
+        DISCORD_USERNAME: 'ALT-F4 Bot'	
+        DISCORD_AVATAR: 'https://raw.githubusercontent.com/AlternativeFFFF/Alt-F4/master/assets/GLOBAL/img/spider.png'	
+      uses: Ilshidur/action-discord@0.2.0	
+      with:	
+        args: "{{ EVENT_PAYLOAD.pull_request.title }} has been updated.\nCurrent labels are {{ EVENT_PAYLOAD.pull_request.labels }}\n{{ EVENT_PAYLOAD.pull_request.html_url }}"

--- a/.github/workflows/PR_Labeled_Notify.yml
+++ b/.github/workflows/PR_Labeled_Notify.yml
@@ -10,7 +10,7 @@ on:
 jobs:	
   notify:	
     name: Notification	
-    #if: github.repository == 'AlternativeFFFF/Alt-F4'	
+    if: github.repository == 'AlternativeFFFF/Alt-F4'	
     runs-on: ubuntu-latest	
     steps:	
 
@@ -30,4 +30,4 @@ jobs:
         DISCORD_AVATAR: 'https://raw.githubusercontent.com/AlternativeFFFF/Alt-F4/master/assets/GLOBAL/img/spider.png'	
       uses: Ilshidur/action-discord@0.2.0	
       with:	
-        args: "*{{ EVENT_PAYLOAD.pull_request.title }}* - has been updated.\nCurrent labels are {{ EVENT_PAYLOAD.pull_request.labels }}\n{{ EVENT_PAYLOAD.pull_request.html_url }}"
+        args: "*{{ EVENT_PAYLOAD.pull_request.title }}* - has been updated.\n{{ EVENT_PAYLOAD.pull_request.html_url }}"


### PR DESCRIPTION
I'd like a Github Action to autopost when a submission PR has a label change and the new set of labels.

I have the basic setup but I'm struggling with getting the labels to display since there won't be a fixed amount and the label pull request thing is an object. Im guessing I need some kind of loop but idk how I'd implement that in a github action.

Current behaviour: 
![image](https://user-images.githubusercontent.com/34628734/100643773-63c26e00-3332-11eb-9b26-cf8080062b88.png)
